### PR TITLE
Fix lottery quantity validation

### DIFF
--- a/Task_2/task_2.py
+++ b/Task_2/task_2.py
@@ -5,10 +5,17 @@ MAX_ALLOWED_NUMBER = 1000
 
 def get_numbers_ticket(min_val: int, max_val: int, quantity: int):
     try:
-        if (min_val < MIN_ALLOWED_NUMBER or max_val > MAX_ALLOWED_NUMBER
-                or quantity < min_val or quantity > max_val):
+        if (
+            min_val < MIN_ALLOWED_NUMBER
+            or max_val > MAX_ALLOWED_NUMBER
+            or min_val > max_val
+            or quantity < 1
+            or quantity > (max_val - min_val + 1)
+        ):
             raise ValueError
+
         return sorted(random.sample(range(min_val, max_val + 1), quantity))
+
     except ValueError:
         print("Wrong parameters.")
         return list()


### PR DESCRIPTION
## Summary
- fix validation for quantity and bounds in get_numbers_ticket

## Testing
- `python3 Task_2/task_2.py`
- `python3 - <<'PY'
from Task_2.task_2 import get_numbers_ticket
print(get_numbers_ticket(1, 1000, 1001))
print(get_numbers_ticket(50, 40, 1))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68519c6f313c832482d84c4269e6f2c3